### PR TITLE
get neoscopes selected scope

### DIFF
--- a/lua/neoscopes.lua
+++ b/lua/neoscopes.lua
@@ -379,5 +379,11 @@ M.get_all_scopes = function()
   return scopes
 end
 
+---Returns the current selected scope
+M.get_current_scope = function()
+	return current_scope.name or ""
+end
+
+
 return M
 


### PR DESCRIPTION
added a function to call the name of the current selected scope

it's tiny but useful for me, because it can show me the selected scope in my nvim-lualine.. i have config like this

```lua
-- sections
lualine_x = { "encoding", "fileformat", "filetype", "require'neoscopes'.get_current_scope()" },
```

