### PR TITLE
Initialize config if not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,25 @@ extension hooks for your custom logic.
 
 ## Installation
 
+Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
 ```lua
 -- Optionally, install telescope for nicer scope selection UI.
 use {"nvim-telescope/telescope.nvim"}
 
 -- Install neoscopes.
 use {"smartpde/neoscopes"}
+```
+
+Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+  {
+    'smartpde/neoscopes',
+    -- Optionally, install telescope for nicer scope selection UI.
+    dependencies = { 'nvim-telescope/telescope.nvim' },
+    config = true,
+  }
 ```
 
 ## Registering scopes

--- a/lua/neoscopes.lua
+++ b/lua/neoscopes.lua
@@ -142,7 +142,7 @@ end
 ---@param config Config the configuration object
 M.setup = function(config)
   if not config then
-    return
+    config = {}
   end
   local project_level_config_filename = config.neoscopes_config_filename or
                                           'neoscopes.config.json'


### PR DESCRIPTION
The `setup` function is not run if a config is not provided. Use an empty config instead.

Fixes #14 